### PR TITLE
updating base URL for sonarqube

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube-scanner-node",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "sonarqube-scanner npm package",
   "main": "src/index.js",
   "repository": {

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ var path = require('path');
 var platform = require('./platform');
 
 const SONAR_SCANNER_CLI_VERSION = '3.0.3.778';
-const SONAR_SCANNER_BASE_URL = 'https://sonarsource.bintray.com/Distribution/sonar-scanner-cli';
+const SONAR_SCANNER_BASE_URL = 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli';
 const SONAR_SCANNER_CLI_FOLDER = `sonar-scanner-${SONAR_SCANNER_CLI_VERSION}`;
 const SONAR_SCANNER_CLI_WITH_JRE_FOLDER = `${SONAR_SCANNER_CLI_FOLDER}-${platform.name}`;
 const SONAR_SCANNER_URL = `${SONAR_SCANNER_BASE_URL}/sonar-scanner-cli-${SONAR_SCANNER_CLI_VERSION}.zip`;


### PR DESCRIPTION
Sonarsource switched recently from Bintray to their own download site.
Please change https://sonarsource.bintray.com to https://binaries.sonarsource.com

Here is the announcement they did on our community forum: https://community.sonarsource.com/t/download-site-has-changed/3176